### PR TITLE
added file highlight with metadata

### DIFF
--- a/force-app/main/default/JavaScript/FileHighlight.js
+++ b/force-app/main/default/JavaScript/FileHighlight.js
@@ -1,0 +1,147 @@
+ 
+
+import getKeywordColorMap from "@salesforce/apex/CommonUtility.getKeywordColorMap"; 
+
+const contentDocumentLinkColumns = [
+    {
+      label: "File Name",
+      fieldName: "id",
+      type: "filePreview",
+      sortable: "true",
+      wrapText: true,
+      typeAttributes: {
+        anchorText: { fieldName: "title" },
+        versionId: { fieldName: "latestVersionId" }
+      },
+      cellAttributes: { alignment: 'center' , class: { fieldName: 'cssClass' }}
+    },
+    { label: "Uploaded Date", fieldName: "createdDate", sortable: "true", type: "date" ,cellAttributes: { alignment: 'center' , class: { fieldName: 'cssClass' }}},
+    { label: "Uploaded by", fieldName: "createdBy", wrapText: true, sortable: "true", type: "string",cellAttributes: { alignment: 'center' , class: { fieldName: 'cssClass' }} },
+    { type: "action", typeAttributes: { rowActions: actions },cellAttributes: { alignment: 'center' , class: { fieldName: 'cssClass' }} }
+  ];
+files=[];
+// Get the keyword color map from the server
+ getKeywordColorMap()
+      .then(result => {
+        if (result) {
+          console.log('Metadata result--->', JSON.stringify(result));
+
+          const excludeKeywordsList = result.excludeKeywordsList || [];
+          const includeMap = result.includeMap || {};
+
+          const keywordColorMap = new Map();
+          Object.keys(includeMap).forEach(colorCode => {
+            const keywords = includeMap[colorCode];
+            keywords.forEach(keyword => {
+              const processedKeyword = keyword.toLowerCase().trim();
+              
+              keywordColorMap.set(processedKeyword, {
+                original: keyword,
+                exact: processedKeyword,
+                colorCode: colorCode
+              });
+            });
+          });
+
+          console.log('keywordColorMap--->', JSON.stringify(Object.fromEntries(keywordColorMap)));
+
+          const processedExcludeKeywords = excludeKeywordsList.map(keyword => 
+            keyword.toLowerCase().trim()
+          );
+
+          this.files = this.files.map(row => {
+            const lowerCaseTitle = row.title.toLowerCase().trim();
+            const titleWords = lowerCaseTitle.split(/\s+/);
+
+            const shouldExclude = processedExcludeKeywords.some(excludeKeyword => {
+              const excludeWords = excludeKeyword.split(/\s+/);
+              
+              let foundIndex = -1;
+              return excludeWords.every((word, index) => {
+                if (index === 0) {
+                  foundIndex = titleWords.findIndex(titleWord => 
+                    titleWord === word
+                  );
+                  return foundIndex !== -1;
+                } else {
+                  const nextWordIndex = foundIndex + index;
+                  return nextWordIndex < titleWords.length && 
+                  titleWords[nextWordIndex] === word;
+                }
+              });
+            });
+
+            if (shouldExclude) {
+              console.log('File excluded due to matching exclude keyword:', lowerCaseTitle);
+              return row;
+            }
+
+            for (const [keyword, matchInfo] of keywordColorMap) {
+              if (lowerCaseTitle === keyword) {
+                const colorClass = 'slds-icon-custom-' + matchInfo.colorCode + ' slds-text-color_default';
+                console.log('Exact match found for keyword:', keyword, 'Color code:', matchInfo.colorCode);
+                return {
+                  ...row,
+                  cssClass: colorClass
+                };
+              }
+            }
+
+            let bestMatch = null;
+            let bestMatchLength = 0;
+
+            for (const [keyword, matchInfo] of keywordColorMap) {
+              const keywordWords = keyword.split(/\s+/);
+              
+              let foundIndex = -1;
+              const isMatch = keywordWords.every((word, index) => {
+                if (index === 0) {
+                  foundIndex = titleWords.findIndex(titleWord => 
+                    titleWord.includes(word) || word.includes(titleWord)
+                  );
+                  return foundIndex !== -1;
+                } else {
+                  const nextWordIndex = foundIndex + index;
+                  return nextWordIndex < titleWords.length && 
+                    (titleWords[nextWordIndex].includes(word) || 
+                    word.includes(titleWords[nextWordIndex]));
+                }
+              });
+
+              if (isMatch && keyword.length > bestMatchLength) {
+                bestMatch = matchInfo;
+                bestMatchLength = keyword.length;
+              }
+            }
+
+            if (bestMatch) {
+              const colorClass = 'slds-icon-custom-' + bestMatch.colorCode + ' slds-text-color_default';
+              console.log('Partial match found for keyword:', bestMatch.exact, 'Color code:', bestMatch.colorCode);
+              return {
+                ...row,
+                cssClass: colorClass 
+              };
+            }
+
+            return row;
+          });
+
+          console.log('Updated files--->', JSON.stringify(this.files));
+        }
+      })
+      .catch(error => {
+        console.log('Error in getKeywordColorMap:', error);
+      }); 
+      
+
+
+
+
+
+
+
+
+
+
+
+

--- a/force-app/main/default/classes/CommonUtility.cls
+++ b/force-app/main/default/classes/CommonUtility.cls
@@ -7,6 +7,8 @@
 **/
 
 public with sharing class CommonUtility {
+
+
     public static void collateChildFieldsOnParent(
         List<SObject> triggerNewRecords,
         List<SObject> triggerOldRecords,
@@ -293,6 +295,97 @@ public with sharing class CommonUtility {
             HelperAudit.updateAudit('collateChildFieldsOnParent', strAuditTrailLogText, status);
         }
     }
+
+
+    @AuraEnabled
+    public static Map<String, Object> getKeywordColorMap() {
+        String strAuditTrailLogText = '\nStarted--->';
+        Boolean status = false;
+        
+        Map<String, Object> resultMap = new Map<String, Object>();
+        Map<String, List<String>> includeMap = new Map<String, List<String>>();
+        List<String> excludeKeywordsList = new List<String>();
+        Map<String, DateTime> keywordCreationMap = new Map<String, DateTime>(); 
+    
+        try {
+    
+            List<Keyword_Color_Map__mdt> keywordColorMapList = [
+                SELECT Id, Color__c, Active__c, Type__c, Created_Date__c, Keywords__c
+                FROM Keyword_Color_Map__mdt
+                WHERE Active__c = true ORDER BY Created_Date__c ASC
+            ];
+    
+            strAuditTrailLogText += '\n list of records--->' + keywordColorMapList;
+    
+           
+            Map<String, Schema.SObjectType> schemaMap = Schema.getGlobalDescribe();
+            Schema.SObjectType customMetadataType = schemaMap.get('Keyword_Color_Map__mdt');
+            Map<String, Schema.SObjectField> fieldMap = customMetadataType.getDescribe().fields.getMap();
+            List<Schema.PicklistEntry> picklistEntries = fieldMap.get('Color__c').getDescribe().getPicklistValues();
+    
+            for (Keyword_Color_Map__mdt record : keywordColorMapList) {
+                if (record.Keywords__c != null) {
+                    List<String> keywords = record.Keywords__c.contains('|') 
+                        ? new List<String>(record.Keywords__c.split('\\|'))
+                        : new List<String>{record.Keywords__c};
+                    
+                    for (Integer i = 0; i < keywords.size(); i++) {
+                        keywords[i] = keywords[i].trim();
+                    }
+    
+                    if (record.Type__c == 'Include' && record.Color__c != null) {
+                        List<String> updatedKeywords = includeMap.containsKey(record.Color__c) 
+                            ? includeMap.get(record.Color__c) 
+                            : new List<String>();
+    
+                        for (String keyword : keywords) {
+                            if (!keywordCreationMap.containsKey(keyword) || 
+                                keywordCreationMap.get(keyword) > record.Created_Date__c) {
+                                keywordCreationMap.put(keyword, record.Created_Date__c); 
+                                
+                                if (!updatedKeywords.contains(keyword)) {
+                                    updatedKeywords.add(keyword);
+                                }
+                            }
+                        }
+                        
+                        includeMap.put(record.Color__c, updatedKeywords);
+                    } else if (record.Type__c == 'Exclude') {
+                        excludeKeywordsList.addAll(keywords);
+                    }
+                }
+            }
+    
+            for (String excludeKeyword : excludeKeywordsList) {
+                for (String color : includeMap.keySet()) {
+                    List<String> colorKeywords = includeMap.get(color);
+                    
+                    Integer index = colorKeywords.indexOf(excludeKeyword);
+                    if (index != -1) { 
+                        colorKeywords.remove(index);
+                    }
+                    
+    
+                    includeMap.put(color, colorKeywords);
+                }
+            }
+    
+            resultMap.put('includeMap', includeMap);
+            resultMap.put('excludeKeywordsList', excludeKeywordsList);
+            
+            if (!keywordColorMapList.isEmpty()) {
+                status = true;
+                strAuditTrailLogText += '\n Keyword_Color_Map__mdt records processed successfully--->' + resultMap;
+            }
+            
+        } catch (Exception e) {
+            throw new AuraHandledException(e.getMessage());
+        } finally {
+            HelperAudit.updateAudit('get keyword-color map', strAuditTrailLogText, status);
+        }
+        return resultMap;
+    }
+
     public static Date calculateDate(Date Basedt, decimal yy, string operator,decimal count,string option, string operator1, decimal count1, string option1)
     {
         //system.debug('From Calculate Date---->');      

--- a/force-app/main/default/objects/Keyword_Color_Map__mdt/Keyword_Color_Map__mdt.object-meta.xml
+++ b/force-app/main/default/objects/Keyword_Color_Map__mdt/Keyword_Color_Map__mdt.object-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>This metadata contains the  keywords and thier respective colors</description>
+    <label>Keyword-Color Map</label>
+    <pluralLabel>Keyword-Color Map</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/Keyword_Color_Map__mdt/fields/Active__c.field-meta.xml
+++ b/force-app/main/default/objects/Keyword_Color_Map__mdt/fields/Active__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Active__c</fullName>
+    <defaultValue>true</defaultValue>
+    <description>Tick, if this is an active record and to be considered</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Active</label>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/Keyword_Color_Map__mdt/fields/Color__c.field-meta.xml
+++ b/force-app/main/default/objects/Keyword_Color_Map__mdt/fields/Color__c.field-meta.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Color__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Color</label>
+    <required>false</required>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>-</fullName>
+                <default>true</default>
+                <label>-</label>
+            </value>
+            <value>
+                <fullName>custom7</fullName>
+                <default>false</default>
+                <label>Blue</label>
+            </value>
+            <value>
+                <fullName>custom19</fullName>
+                <default>false</default>
+                <label>Green</label>
+            </value>
+            <value>
+                <fullName>custom23</fullName>
+                <default>false</default>
+                <label>Lavender</label>
+            </value>
+            <value>
+                <fullName>custom34</fullName>
+                <default>false</default>
+                <label>Orange</label>
+            </value>
+            <value>
+                <fullName>custom55</fullName>
+                <default>false</default>
+                <label>Pink</label>
+            </value>
+            <value>
+                <fullName>custom35</fullName>
+                <default>false</default>
+                <label>Red</label>
+            </value>
+            <value>
+                <fullName>custom16</fullName>
+                <default>false</default>
+                <label>Yellow</label>
+            </value>
+            <value>
+                <fullName>custom43</fullName>
+                <default>false</default>
+                <label>Lavender Blue Shadow</label>
+            </value>
+            <value>
+                <fullName>custom38</fullName>
+                <default>false</default>
+                <label>Blue Martini</label>
+            </value>
+            <value>
+                <fullName>custom26</fullName>
+                <default>false</default>
+                <label>Guilliman Blue</label>
+            </value>
+            <value>
+                <fullName>custom61</fullName>
+                <default>false</default>
+                <label>Georgia Peach</label>
+            </value>
+            <value>
+                <fullName>custom57</fullName>
+                <default>false</default>
+                <label>Blue Bay</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/Keyword_Color_Map__mdt/fields/Created_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Keyword_Color_Map__mdt/fields/Created_Date__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Created_Date__c</fullName>
+    <defaultValue>now()</defaultValue>
+    <description>This field captures the date and time when the record is initially created.</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Created Date</label>
+    <required>false</required>
+    <type>DateTime</type>
+</CustomField>

--- a/force-app/main/default/objects/Keyword_Color_Map__mdt/fields/Keywords__c.field-meta.xml
+++ b/force-app/main/default/objects/Keyword_Color_Map__mdt/fields/Keywords__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Keywords__c</fullName>
+    <description>This field is a replacement fo the keyword__C field as we need to store all the keywords in a single record with a separator( &apos; , &apos;    &apos; | &apos; )</description>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>Please enter your keywords, separated by a vertical bar (|). For example: keyword1 | keyword2 | keyword3</inlineHelpText>
+    <label>Keywords</label>
+    <length>32768</length>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/Keyword_Color_Map__mdt/fields/Type__c.field-meta.xml
+++ b/force-app/main/default/objects/Keyword_Color_Map__mdt/fields/Type__c.field-meta.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Type__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <label>Type</label>
+    <required>true</required>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Include</fullName>
+                <default>true</default>
+                <label>Include</label>
+            </value>
+            <value>
+                <fullName>Exclude</fullName>
+                <default>false</default>
+                <label>Exclude</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/Keyword_Color_Map__mdt/listViews/all_fields.listView-meta.xml
+++ b/force-app/main/default/objects/Keyword_Color_Map__mdt/listViews/all_fields.listView-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>all_fields</fullName>
+    <columns>DeveloperName</columns>
+    <columns>Type__c</columns>
+    <columns>Color__c</columns>
+    <columns>Keywords__c</columns>
+    <columns>Created_Date__c</columns>
+    <filterScope>Everything</filterScope>
+    <label>all fields</label>
+</ListView>

--- a/force-app/main/default/objects/Keyword_Color_Map__mdt/validationRules/ExcludeInclude_Color.validationRule-meta.xml
+++ b/force-app/main/default/objects/Keyword_Color_Map__mdt/validationRules/ExcludeInclude_Color.validationRule-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ExcludeInclude_Color</fullName>
+    <active>true</active>
+    <description>When Exclude then Color is optional</description>
+    <errorConditionFormula>IF(
+  ISPICKVAL(Type__c, &apos;Exclude&apos;), 
+  IF(ISPICKVAL(Color__c, &apos;-&apos;), false, true), 
+  IF(
+    ISPICKVAL(Type__c, &apos;Include&apos;), 
+    IF(ISPICKVAL(Color__c, &apos;-&apos;), true, false), 
+    false
+  )
+)</errorConditionFormula>
+    <errorDisplayField>Color__c</errorDisplayField>
+    <errorMessage>Please input Valid Data.</errorMessage>
+</ValidationRule>

--- a/force-app/main/default/objects/Keyword_Color_Map__mdt/validationRules/KeywordsCannotBeBlank.validationRule-meta.xml
+++ b/force-app/main/default/objects/Keyword_Color_Map__mdt/validationRules/KeywordsCannotBeBlank.validationRule-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>KeywordsCannotBeBlank</fullName>
+    <active>true</active>
+    <errorConditionFormula>ISBLANK(Keywords__c)</errorConditionFormula>
+    <errorDisplayField>Keywords__c</errorDisplayField>
+    <errorMessage>Keywords cannot be blank</errorMessage>
+</ValidationRule>


### PR DESCRIPTION
This PR introduces a file highlighting feature that includes the metadata model. With this enhancement, we can apply custom colors to cells in a data table without relying on external CSS. This addresses a limitation in the standard Lightning Data Table, which doesn't natively support cell color customization.